### PR TITLE
Bugfix: reset function ignored "missing" status

### DIFF
--- a/src/HaltingAnalysis.ts
+++ b/src/HaltingAnalysis.ts
@@ -108,7 +108,7 @@ export function createAnalysisStructure(
 
 // Reset any analysis data between passes
 function reset(nodes: AnalysisNode[]) {
-  nodes.forEach(n => (n.live = true));
+  nodes.forEach(n => n.status !== 'missing' ? n.live = true : n.live = false);
 }
 
 /*


### PR DESCRIPTION
When resetting the analysis structure before exploring a new failure case, missing nodes were marked as live nodes.